### PR TITLE
move err msg strings to frozen constants

### DIFF
--- a/lib/processor.rb
+++ b/lib/processor.rb
@@ -2,6 +2,11 @@ require_relative 'formatter'
 
 class Processor
 
+  ERR_INPUT_REQ = "-i FILE option for input file required".freeze
+  ERR_OUTPUT_REQ = "-o FILE option for output file required".freeze
+  ERR_INPUT_MISSING = "input file must exist".freeze
+  ERR_OUTPUT_MISSING = "output file must not exist".freeze
+
   attr_accessor :errors
 
   def initialize(options:, stderr: $stderr)
@@ -13,17 +18,17 @@ class Processor
     @errors = []
 
     if !@options.has_key?(:in)
-      @errors << "-i FILE option for input file required"
+      @errors << ERR_INPUT_REQ
     end
     if !@options.has_key?(:out)
-      @errors << "-o FILE option for output file required"
+      @errors << ERR_OUTPUT_REQ
     end
 
     if @options.include?(:in) && !File.file?(@options[:in])
-      @errors << "input file must exist"
+      @errors << ERR_INPUT_MISSING
     end
     if @options.include?(:out) && File.file?(@options[:out])
-      @errors << "output file must not exist"
+      @errors << ERR_OUTPUT_MISSING
     end
   end
 

--- a/lib/processor.rb
+++ b/lib/processor.rb
@@ -1,11 +1,13 @@
+# frozen_string_literal: true
+
 require_relative 'formatter'
 
 class Processor
 
-  ERR_INPUT_REQ = "-i FILE option for input file required".freeze
-  ERR_OUTPUT_REQ = "-o FILE option for output file required".freeze
-  ERR_INPUT_MISSING = "input file must exist".freeze
-  ERR_OUTPUT_MISSING = "output file must not exist".freeze
+  ERR_INPUT_REQ = "-i FILE option for input file required"
+  ERR_OUTPUT_REQ = "-o FILE option for output file required"
+  ERR_INPUT_MISSING = "input file must exist"
+  ERR_OUTPUT_MISSING = "output file must not exist"
 
   attr_accessor :errors
 

--- a/lib/processor.rb
+++ b/lib/processor.rb
@@ -4,10 +4,10 @@ require_relative 'formatter'
 
 class Processor
 
-  ERR_INPUT_REQ = "-i FILE option for input file required"
-  ERR_OUTPUT_REQ = "-o FILE option for output file required"
-  ERR_INPUT_MISSING = "input file must exist"
-  ERR_OUTPUT_MISSING = "output file must not exist"
+  ERROR_INPUT_OPTION_MISSING = "-i FILE option for input file required"
+  ERROR_OUTPUT_OPTION_MISSING = "-o FILE option for output file required"
+  ERROR_INPUT_FILE_NOT_FOUND = "input file must exist"
+  ERROR_OUTPUT_FILE_FOUND = "output file must not exist"
 
   attr_accessor :errors
 
@@ -20,17 +20,17 @@ class Processor
     @errors = []
 
     if !@options.has_key?(:in)
-      @errors << ERR_INPUT_REQ
+      @errors << ERROR_INPUT_OPTION_MISSING
     end
     if !@options.has_key?(:out)
-      @errors << ERR_OUTPUT_REQ
+      @errors << ERROR_OUTPUT_OPTION_MISSING
     end
 
     if @options.include?(:in) && !File.file?(@options[:in])
-      @errors << ERR_INPUT_MISSING
+      @errors << ERROR_INPUT_FILE_NOT_FOUND
     end
     if @options.include?(:out) && File.file?(@options[:out])
-      @errors << ERR_OUTPUT_MISSING
+      @errors << ERROR_OUTPUT_FILE_FOUND
     end
   end
 


### PR DESCRIPTION
moving Error message string into constant string that are frozen.

at minimum you should freeze strings in place 

Since there isn't any reuse making a constant is low value, but giving them a constant name is the beginning of giving them a key for a external file for i13n values